### PR TITLE
Font update from Source Sans Pro to Lato

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -5,7 +5,7 @@
     <meta name="author" content="Collective Logic Ltd">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400,700" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Lato:300,400" rel="stylesheet">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.12/css/all.css" integrity="sha384-G0fIWCsCzJIMAVNQPfjH08cyYaUtMwjJwqiRKxxE/rx96Uroj1BtIQ6MLJuheaO9" crossorigin="anonymous">
     <link rel="stylesheet" href="{{ site.baseurl }}styles/styles.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -1,6 +1,6 @@
 body {
-    font-family: 'Source Sans Pro', sans-serif;
-    font-weight: 200;
+    font-family: 'Lato', sans-serif;
+    font-weight: 300;
     font-size: 18px;
     margin: 0;
     padding: 0;

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -157,14 +157,13 @@ header {
 
     h2 {
         font-size: 28px;
-        font-weight: 200;
+        font-weight: 300;
         line-height: 36px;
         margin: 24px 0 0;
         color: $white-light;
 
         @media all and (min-width: $content-min-width) {
             font-size: 32px;
-            line-height: 50px;
             margin: 72px 0 0;
         }
 
@@ -184,7 +183,7 @@ main {
     }
 
     h2 {
-        font-weight: 200;
+        font-weight: 300;
         color: $primary-main;
         font-size: 26px;
         margin-top: 8px;


### PR DESCRIPTION
Changed the font from `Source Sans Pro` to `Lato` to better match the logo font dimensions (Lato is a wider character font). Will also tie in better with business cards.

For reference:
**Source Sans Pro** - https://fonts.google.com/specimen/Source+Sans+Pro
**Lato** - https://fonts.google.com/specimen/Lato